### PR TITLE
Remove Rice::Array::to_c_array

### DIFF
--- a/rice/Array.hpp
+++ b/rice/Array.hpp
@@ -99,13 +99,6 @@ public:
    */
   Object shift();
 
-  //! Return a pointer to the beginning of a C array containing
-  //! the VALUEs stored in this Array.
-  //! Use with caution!
-  /*! \return a pointer to the beginning of the array.
-   */
-  VALUE * to_c_array();
-
 private:
   template<typename Array_Ref_T, typename Value_T>
   class Iterator;

--- a/rice/Array.ipp
+++ b/rice/Array.ipp
@@ -87,20 +87,6 @@ shift()
   return protect(rb_ary_shift, value());
 }
 
-inline VALUE * Rice::Array::
-to_c_array()
-{
-  std::vector<VALUE> arr(size());
-
-  Array::const_iterator it = this->begin();
-  Array::const_iterator e =  this->end();
-  for(int i = 0 ;it != e; i++, ++it) {
-    arr[i] = it->value();
-  }
-
-  return arr.data();
-}
-
 inline size_t Rice::Array::
 position_of(ptrdiff_t index) const
 {

--- a/rice/Object.cpp
+++ b/rice/Object.cpp
@@ -108,7 +108,16 @@ vcall(
     Identifier id,
     Array args)
 {
-  return protect(rb_funcall3, *this, id, args.size(), args.to_c_array());
+  std::vector<VALUE> a(args.size());
+
+  Array::const_iterator it  = args.begin();
+  Array::const_iterator end = args.end();
+
+  for(int i = 0 ;it != end; i++, ++it) {
+    a[i] = it->value();
+  }
+
+  return protect(rb_funcall3, *this, id, args.size(), &a[0]);
 }
 
 void Rice::Object::

--- a/test/test_Array.cpp
+++ b/test/test_Array.cpp
@@ -156,20 +156,6 @@ TESTCASE(shift)
   ASSERT_EQUAL(44, from_ruby<int>(a[1]));
 }
 
-TESTCASE(to_c_array)
-{
-  Array a;
-  a.push(to_ruby(42));
-  a.push(to_ruby(43));
-  a.push(to_ruby(44));
-
-  const VALUE* out = a.to_c_array();
-
-  ASSERT_EQUAL(42, from_ruby<int>(out[0]));
-  ASSERT_EQUAL(43, from_ruby<int>(out[1]));
-  ASSERT_EQUAL(44, from_ruby<int>(out[2]));
-}
-
 TESTCASE(iterate)
 {
   Array a;


### PR DESCRIPTION
This was previously using RARRAY_PTR, which no longer compiles nicely in
some versions of g++ and also exposes internals of Ruby. Ruby is working
on hiding more of these internals, so we are dropping this method
entirely. Rewrote Rice::Object::vcall to do it's own building of a
c-array for rb_funcall3.