### PR TITLE
Fix from_ruby<char const*> to return Ruby String handle directly

### DIFF
--- a/rice/to_from_ruby.ipp
+++ b/rice/to_from_ruby.ipp
@@ -261,7 +261,7 @@ template<>
 inline
 char const * from_ruby<char const *>(Rice::Object x)
 {
-  return Rice::String(x).str().data();
+  return Rice::String(x).c_str();
 }
 
 template<>


### PR DESCRIPTION
https://github.com/jasonroelofs/rice/issues/97

`Rice::String(x).str()` would create a temporary std::string on the stack, and returning a pointer to its data could result in memory corruption when newly malloc'd memory was changed. This change removes the need for that temporary copy, and instead returns a pointer to the underlying Ruby string's memory, which will not be freed until that Ruby object is off of the C/C++ stack and is unreachable by Ruby code.