### PR TITLE
properly use passed begin/end function ptrs to get respective iterators

### DIFF
--- a/rice/detail/Iterator.hpp
+++ b/rice/detail/Iterator.hpp
@@ -48,8 +48,8 @@ public:
   virtual VALUE call_impl(VALUE self)
   {
     Data_Object<T> obj(self, data_type_);
-    Iterator_T it = obj->begin();
-    Iterator_T end = obj->end();
+    Iterator_T it = (*obj.*begin_)();
+    Iterator_T end = (*obj.*end_)();
     for(; it != end; ++it)
     {
       Rice::protect(rb_yield, to_ruby(*it));

--- a/test/test_Class.cpp
+++ b/test/test_Class.cpp
@@ -303,8 +303,10 @@ public:
   {
   }
 
-  int * begin() { return array_; }
-  int * end() { return array_ + length_; }
+  // Custom names to make sure we call the function pointers rather than
+  // expectable default names.
+  int * beginFoo() { return array_; }
+  int * endBar() { return array_ + length_; }
 
 private:
   int * array_;
@@ -325,7 +327,7 @@ TESTCASE(define_iterator)
 {
   int array[] = { 1, 2, 3 };
   Class c(anonymous_class());
-  c.define_iterator(&Container::begin, &Container::end);
+  c.define_iterator(&Container::beginFoo, &Container::endBar);
   Container * container = new Container(array, 3);
   Object wrapped_container = Data_Wrap_Struct(
       c, 0, Default_Free_Function<Container>::free, container);


### PR DESCRIPTION
previously we'd ignore the passed ptrs and always call `begin()`/`end()`
making the ptrs entirely useless.
the new calls properly go to the passed functions on the object we want to
iter on.

adjusted iter test to make sure this continues working

Fixes #103