### PR TITLE
Compiler finds iconv.h?

### DIFF
--- a/extconf.rb
+++ b/extconf.rb
@@ -33,10 +33,8 @@ EOC
 end
 
 if RUBY_PLATFORM =~ /darwin(\d+)/
-  check_inconv = <<SYSCMD.chomp
-echo "#include <iconv.h>" | g++ -xc -fsyntax-only -
-SYSCMD
-  if system(check_iconv)
+  check_iconv = 'echo "#include <iconv.h>" | g++ -xc -fsyntax-only -'
+  if !system(check_iconv)
     abort <<EOM.chomp
 -----
 The file "/usr/include/iconv.h" is missing in your build environment,

--- a/extconf.rb
+++ b/extconf.rb
@@ -33,8 +33,10 @@ EOC
 end
 
 if RUBY_PLATFORM =~ /darwin(\d+)/
-  # TY Nokogiri!
-  if !File.exist?('/usr/include/iconv.h')
+  check_inconv = <<SYSCMD.chomp
+echo "#include <iconv.h>" | g++ -xc -fsyntax-only -
+SYSCMD
+  if system(check_iconv)
     abort <<EOM.chomp
 -----
 The file "/usr/include/iconv.h" is missing in your build environment,


### PR DESCRIPTION
On my setup libiconv is installed but headers are in a different path with respect to hardcoded one (`/usr/include/iconv.h`). The pull request uses the compiler to check if the specific header is available in the system, no matter what the installation directory.