### PR TITLE
Use `rb_define_method_id`

### DIFF
--- a/rice/detail/method_data.cpp
+++ b/rice/detail/method_data.cpp
@@ -75,9 +75,9 @@ define_method_with_data(
   rb_ivar_set(store, id, data);
 
   // Create the aliased method on the origin class
-  rb_define_method(
+  rb_define_method_id(
       klass,
-      rb_id2name(id),
+      id,
       cfunc,
       arity);
 


### PR DESCRIPTION
It is faster than `rb_define_method` with conversion from ID to its name and back.