### PR TITLE
Fix undefined behavior

### DIFF
--- a/rice/Object.cpp
+++ b/rice/Object.cpp
@@ -117,7 +117,7 @@ vcall(
     a[i] = it->value();
   }
 
-  return protect(rb_funcall3, *this, id, (int)args.size(), &a[0]);
+  return protect(rb_funcall3, *this, id, (int)args.size(), a.data());
 }
 
 void Rice::Object::

--- a/rice/Object.ipp
+++ b/rice/Object.ipp
@@ -12,7 +12,7 @@ inline Rice::Object Rice::Object::
 call(Identifier id, ArgT... args) const
 {
   auto asList = this->convert_args<ArgT...>(args...);
-  return protect(rb_funcall2, value(), id, (int)asList.size(), &asList[0]);
+  return protect(rb_funcall2, value(), id, (int)asList.size(), asList.data());
 }
 
 template<typename ...ArgT>


### PR DESCRIPTION
When the number of arguments to a method call is 0, then the asList vector has a size of zero. In that case, calling asList[0] is undefined behavior although with GCC it works fine in a debug mode (but per the C++ spec you aren't supposed to do that). On MSVC in debug mode that causes a crash. Instead, data() should be used instead.

Note a second way of solving this would be to specialize the call template like this:

template<>
inline Rice::Object Rice::Object::
call(Identifier id) const
{
    return protect(rb_funcall, value(), id, 0);
}

I like that better but it seemed like a more invasive change.