### PR TITLE
Fix Compiler Warnings - Array

### DIFF
--- a/rice/Array.hpp
+++ b/rice/Array.hpp
@@ -46,12 +46,12 @@ public:
   //! Construct an Array from a C array.
   /*! \param a a C array of type T and size n.
    */
-  template<typename T, size_t n>
+  template<typename T, long n>
   Array(T const (& a)[n]);
 
 public:
   //! Return the size of the array.
-  size_t size() const;
+  long size() const;
 
   //! Return the element at the given index.
   /*! \param index The index of the desired element.  The index may be
@@ -59,7 +59,7 @@ public:
    *  index is out of bounds, this function has undefined behavior.
    *  \return the element at the given index.
    */
-  Object operator[](ptrdiff_t index) const;
+  Object operator[](long index) const;
 
 private:
   //! A helper class so array[index]=value can work.
@@ -72,7 +72,7 @@ public:
    *  index is out of bounds, this function has undefined behavior.
    *  \return the element at the given index.
    */
-  Proxy operator[](ptrdiff_t index);
+  Proxy operator[](long index);
 
   //! Push an element onto the end of the array
   /*! \param v an object to push onto the array.
@@ -103,7 +103,7 @@ private:
   template<typename Array_Ref_T, typename Value_T>
   class Iterator;
 
-  size_t position_of(ptrdiff_t index) const;
+  long position_of(long index) const;
 
 public:
   //! An iterator.
@@ -130,7 +130,7 @@ class Array::Proxy
 {
 public:
   //! Construct a new Proxy
-  Proxy(Array array, size_t index);
+  Proxy(Array array, long index);
 
   //! Implicit conversion to Object.
   operator Object() const;
@@ -144,7 +144,7 @@ public:
 
 private:
   Array array_;
-  size_t index_;
+  long index_;
 };
 
 //! A helper class for implementing iterators for a Array.
@@ -154,12 +154,12 @@ class Array::Iterator
   : public std::iterator<
       std::forward_iterator_tag,
       Value_T,            // Type
-      ptrdiff_t,          // Distance type
+      long,               // Distance type
       Object *,           // Pointer type
       Value_T &>          // Reference type
 {
 public:
-  Iterator(Array_Ref_T array, size_t index);
+  Iterator(Array_Ref_T array, long index);
 
   template<typename Array_Ref_T_, typename Value_T_>
   Iterator(Iterator<Array_Ref_T_, Value_T_> const & rhs);
@@ -183,11 +183,11 @@ public:
   // friend class Iterator;
 
   Array_Ref_T array() const;
-  size_t index() const;
+  long index() const;
 
 private:
   Array_Ref_T array_;
-  size_t index_;
+  long index_;
 
   Object tmp_;
 };

--- a/rice/Array.ipp
+++ b/rice/Array.ipp
@@ -32,31 +32,31 @@ Array(Iter_T it, Iter_T end)
   }
 }
 
-template<typename T, size_t n>
+template<typename T, long n>
 inline Rice::Array::
 Array(T const (& a)[n])
   : Builtin_Object<T_ARRAY>(protect(rb_ary_new))
 {
-  for(size_t j = 0; j < n; ++j)
+  for(long j = 0; j < n; ++j)
   {
     push(a[j]);
   }
 }
 
-inline size_t Rice::Array::
+inline long Rice::Array::
 size() const
 {
   return RARRAY_LEN(this->value());
 }
 
 inline Rice::Object Rice::Array::
-operator[](ptrdiff_t index) const
+operator[](long index) const
 {
   return protect(rb_ary_entry, value(), position_of(index));
 }
 
 inline Rice::Array::Proxy Rice::Array::
-operator[](ptrdiff_t index)
+operator[](long index)
 {
   return Proxy(*this, position_of(index));
 }
@@ -87,8 +87,8 @@ shift()
   return protect(rb_ary_shift, value());
 }
 
-inline size_t Rice::Array::
-position_of(ptrdiff_t index) const
+inline long Rice::Array::
+position_of(long index) const
 {
   if(index < 0)
   {
@@ -96,12 +96,12 @@ position_of(ptrdiff_t index) const
   }
   else
   {
-    return static_cast<size_t>(index);
+    return static_cast<long>(index);
   }
 }
 
 inline Rice::Array::Proxy::
-Proxy(Array array, size_t index)
+Proxy(Array array, long index)
   : array_(array)
   , index_(index)
 {
@@ -130,7 +130,7 @@ operator=(T const & value)
 
 template<typename Array_Ref_T, typename Value_T>
 inline Rice::Array::Iterator<Array_Ref_T, Value_T>::
-Iterator(Array_Ref_T array, size_t index)
+Iterator(Array_Ref_T array, long index)
   : array_(array)
   , index_(index)
 {
@@ -221,7 +221,7 @@ array() const
 }
 
 template<typename Array_Ref_T, typename Value_T>
-size_t
+long
 Rice::Array::Iterator<Array_Ref_T, Value_T>::
 index() const
 {


### PR DESCRIPTION
Ruby's Array class uses longs for indexing while Rice's Array class uses both size_t and ptrdiff_t. This mismatch results in *tons* of compiler warnings (at least on MSVC). This commit resolves the warnings by updating Rice's Array to match Ruby's Array class.