### PR TITLE
Fix More Compiler Warnings

### DIFF
--- a/rice/String.cpp
+++ b/rice/String.cpp
@@ -37,7 +37,7 @@ String(char const * s)
 
 Rice::String::
 String(std::string const & s)
-  : Builtin_Object<T_STRING>(protect(rb_str_new, s.data(), s.length()))
+  : Builtin_Object<T_STRING>(protect(rb_str_new, s.data(), (long)s.length()))
 {
 }
 

--- a/rice/Struct.cpp
+++ b/rice/Struct.cpp
@@ -59,11 +59,11 @@ define_member(
   return *this;
 }
 
-size_t Rice::Struct::
+unsigned long Rice::Struct::
 offset_of(Identifier name) const
 {
   Symbol ruby_name(name);
-  return from_ruby<size_t>(member_offset_[ruby_name]);
+  return from_ruby<unsigned long>(member_offset_[ruby_name]);
 }
 
 void Rice::Struct::

--- a/rice/Struct.hpp
+++ b/rice/Struct.hpp
@@ -91,7 +91,7 @@ public:
    *  \param member the name of the desired member.
    *  \return the index of the given member.
    */
-  size_t offset_of(Identifier name) const;
+  unsigned long offset_of(Identifier name) const;
 
   class Instance;
   friend class Instance;

--- a/rice/Struct.ipp
+++ b/rice/Struct.ipp
@@ -12,7 +12,7 @@ template<>
 inline Object Struct::Instance::
 operator[]<Identifier>(Identifier member)
 {
-  size_t index = type_.offset_of(member);
+  unsigned long index = type_.offset_of(member);
   return (*this)[index];
 }
 

--- a/rice/detail/Arguments.hpp
+++ b/rice/detail/Arguments.hpp
@@ -38,7 +38,7 @@ namespace Rice {
        * In the case of no Args (default case), this
        * method uses the passed in full argument count
        */
-      std::string formatString(int fullArgCount)
+      std::string formatString(size_t fullArgCount)
       {
         std::stringstream s;
         if(required_ == 0 && optional_ == 0)

--- a/rice/to_from_ruby.ipp
+++ b/rice/to_from_ruby.ipp
@@ -101,7 +101,7 @@ template<>
 inline
 long from_ruby<long>(Rice::Object x)
 {
-  return Rice::protect(Rice::detail::num2long, x);
+  return (long)Rice::protect(Rice::detail::num2long, x);
 }
 
 template<>
@@ -225,7 +225,7 @@ template<>
 inline
 unsigned long from_ruby<unsigned long>(Rice::Object x)
 {
-  return Rice::protect(Rice::detail::num2ulong, x);
+  return (unsigned long)Rice::protect(Rice::detail::num2ulong, x);
 }
 
 template<>
@@ -407,7 +407,7 @@ template<>
 inline
 Rice::Object to_ruby<std::string>(std::string const & x)
 {
-  return Rice::protect(rb_str_new, x.data(), x.size());
+  return Rice::protect(rb_str_new, x.data(), (long)x.size());
 }
 
 template<>


### PR DESCRIPTION
These two commits fix some more compiler warnings. One of them updates the Rice Struct class to use unsigned longs for offsets to match what the underlying Ruby structs class. The other one is a few odds and ends.
