### PR TITLE
Fix build error in Ruby 3.0 on macOS

### DIFF
--- a/extconf.rb
+++ b/extconf.rb
@@ -55,11 +55,15 @@ EOM
     end
 
     other_opts = "--disable-dependency-tracking"
-    env = "ARCHFLAGS='-arch #{arch}' CPPFLAGS='-arch #{arch}'"
   else
     arch = `uname -p`.chomp
-    env = "ARCHFLAGS='-arch #{arch}' CPPFLAGS='-arch #{arch}'"
   end
+
+  env = if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0.0')
+          "ARCHFLAGS='-arch #{arch}' CPPFLAGS='-fdeclspec -arch #{arch}'"
+        else
+          "ARCHFLAGS='-arch #{arch}' CPPFLAGS='-arch #{arch}'"
+        end
 end
 
 system "sh bootstrap"


### PR DESCRIPTION
I failed to install rice gem on Ruby 3.0 on macOS 11.1.

```
$ ruby -v
ruby 3.0.0preview2 (2020-12-08 master d7a16670c3) [x86_64-darwin20]
$ gem install rice
Building native extensions. This could take a while...

...

checking for ruby.h... no
configure: error: could not find ruby.h (check config.log)

Makefile not found

...
```

I checked config.log and found that it was due to the used of `__declspec` in Ruby 3.

```
In file included from conftest.cpp:14:
In file included from /Users/foo/.anyenv/envs/rbenv/versions/3.0.0-preview2/include/ruby-3.0.0/ruby.h:31:
In file included from /Users/foo/.anyenv/envs/rbenv/versions/3.0.0-preview2/include/ruby-3.0.0/ruby/ruby.h:23:
In file included from /Users/foo/.anyenv/envs/rbenv/versions/3.0.0-preview2/include/ruby-3.0.0/ruby/defines.h:74:
In file included from /Users/foo/.anyenv/envs/rbenv/versions/3.0.0-preview2/include/ruby-3.0.0/ruby/backward/2/attributes.h:43:
In file included from /Users/foo/.anyenv/envs/rbenv/versions/3.0.0-preview2/include/ruby-3.0.0/ruby/internal/attr/pure.h:25:
/Users/foo/.anyenv/envs/rbenv/versions/3.0.0-preview2/include/ruby-3.0.0/ruby/assert.h:132:1: 
error: '__declspec' attributes are not enabled; use '-fdeclspec' or '-fms-extensions' to enable support for __declspec attributes
RBIMPL_ATTR_NORETURN()
^
/Users/foo/.anyenv/envs/rbenv/versions/3.0.0-preview2/include/ruby-3.0.0/ruby/internal/attr/noreturn.h:29:33: 
note: expanded from macro 'RBIMPL_ATTR_NORETURN'
# define RBIMPL_ATTR_NORETURN() __declspec(noreturn)
```

Therefore, I have added `-fdeclspec` to CPPFLAGS in extconf.rb for Ruby 3.0 on macOS.
I have confirmed that the build is successful.