### PR TITLE
Moderinize Iterators

### DIFF
--- a/rice/Array.hpp
+++ b/rice/Array.hpp
@@ -151,14 +151,14 @@ private:
 // TODO: This really should be a random-access iterator.
 template<typename Array_Ref_T, typename Value_T>
 class Array::Iterator
-  : public std::iterator<
-      std::forward_iterator_tag,
-      Value_T,            // Type
-      long,               // Distance type
-      Object *,           // Pointer type
-      Value_T &>          // Reference type
 {
 public:
+  using iterator_category = std::forward_iterator_tag;
+  using value_type = Value_T;
+  using difference_type = long;
+  using pointer = Object*;
+  using reference = Value_T&;  
+  
   Iterator(Array_Ref_T array, long index);
 
   template<typename Array_Ref_T_, typename Value_T_>

--- a/rice/Hash.hpp
+++ b/rice/Hash.hpp
@@ -146,11 +146,14 @@ bool operator<(Hash::Entry const & lhs, Hash::Entry const & rhs);
 //! A helper class for implementing iterators for a Hash.
 template<typename Hash_Ref_T, typename Value_T>
 class Hash::Iterator
-  : public std::iterator<
-      std::input_iterator_tag,
-      Value_T>
 {
 public:
+  using iterator_category = std::input_iterator_tag;
+  using value_type = Value_T;
+  using difference_type = long;
+  using pointer = Object*;
+  using reference = Value_T&;
+
   //! Construct a new Iterator.
   Iterator(Hash_Ref_T hash);
 


### PR DESCRIPTION
Update iterators so they compile with C++17 which deprecates inheriting from std::iterator.