### PR TITLE
Correctly initialize embedded Ruby interpreter.

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -30,6 +30,7 @@ run_multiple_extensions_same_class_test:
 
 
 unittest_SOURCES = \
+	embed_ruby.cpp \
 	unittest.cpp \
 	test_Address_Registration_Guard.cpp \
 	test_Array.cpp \

--- a/test/embed_ruby.cpp
+++ b/test/embed_ruby.cpp
@@ -1,0 +1,21 @@
+#include <ruby.h>
+
+void embed_ruby()
+{
+  static bool initialized__ = false;
+
+  if (!initialized__)
+  {
+    int argc = 0;
+    char* argv = (char*)malloc(1);
+    argv[0] = 0;
+    char** pArgv = &argv;
+
+    ruby_sysinit(&argc, &pArgv);
+    RUBY_INIT_STACK;
+    ruby_init();
+    ruby_init_loadpath();
+
+    initialized__ = true;
+  }
+}

--- a/test/embed_ruby.hpp
+++ b/test/embed_ruby.hpp
@@ -1,0 +1,4 @@
+#ifndef Rice_embed_ruby
+#define Rice_embed_ruby
+void embed_ruby();
+#endif

--- a/test/test_Address_Registration_Guard.cpp
+++ b/test/test_Address_Registration_Guard.cpp
@@ -1,4 +1,5 @@
 #include "unittest.hpp"
+#include "embed_ruby.hpp"
 #include "rice/Address_Registration_Guard.hpp"
 
 using namespace Rice;
@@ -7,7 +8,7 @@ TESTSUITE(Address_Registration_Guard);
 
 SETUP(Address_Registration_Guard)
 {
-  ruby_init();
+  embed_ruby();
 }
 
 TESTCASE(register_address)

--- a/test/test_Array.cpp
+++ b/test/test_Array.cpp
@@ -1,4 +1,5 @@
 #include "unittest.hpp"
+#include "embed_ruby.hpp"
 #include "rice/Array.hpp"
 #include "rice/String.hpp"
 #include "rice/global_function.hpp"
@@ -9,7 +10,7 @@ TESTSUITE(Array);
 
 SETUP(Array)
 {
-  ruby_init();
+  embed_ruby();
 }
 
 TESTCASE(default_construct)

--- a/test/test_Builtin_Object.cpp
+++ b/test/test_Builtin_Object.cpp
@@ -1,4 +1,5 @@
 #include "unittest.hpp"
+#include "embed_ruby.hpp"
 #include "rice/Builtin_Object.hpp"
 #include "rice/Class.hpp"
 
@@ -8,7 +9,7 @@ TESTSUITE(Builtin_Object);
 
 SETUP(Builtin_Object)
 {
-  ruby_init();
+  embed_ruby();
 }
 
 TESTCASE(construct_with_object)

--- a/test/test_Class.cpp
+++ b/test/test_Class.cpp
@@ -1,4 +1,5 @@
 #include "unittest.hpp"
+#include "embed_ruby.hpp"
 #include "rice/Class.hpp"
 #include "rice/Constructor.hpp"
 #include "rice/protect.hpp"
@@ -15,7 +16,7 @@ TESTSUITE(Class);
 
 SETUP(Class)
 {
-  ruby_init();
+  embed_ruby();
 }
 
 TESTCASE(construct)

--- a/test/test_Data_Object.cpp
+++ b/test/test_Data_Object.cpp
@@ -1,4 +1,5 @@
 #include "unittest.hpp"
+#include "embed_ruby.hpp"
 #include "rice/Data_Object.hpp"
 #include "rice/Data_Type.hpp"
 #include "rice/Exception.hpp"
@@ -22,7 +23,7 @@ void ruby_mark(Foo * foo)
 
 SETUP(Data_Object)
 {
-  ruby_init();
+  embed_ruby();
 
   if(!Data_Type<Foo>::is_bound())
   {

--- a/test/test_Data_Type.cpp
+++ b/test/test_Data_Type.cpp
@@ -1,4 +1,5 @@
 #include "unittest.hpp"
+#include "embed_ruby.hpp"
 #include "rice/Data_Type.hpp"
 #include "rice/Exception.hpp"
 #include "rice/Constructor.hpp"
@@ -63,7 +64,7 @@ namespace {
 
 SETUP(Data_Type)
 {
-  ruby_init();
+  embed_ruby();
 
   define_class<Listener>("Listener")
     .define_constructor(Constructor<Listener>())

--- a/test/test_Director.cpp
+++ b/test/test_Director.cpp
@@ -1,4 +1,5 @@
 #include "unittest.hpp"
+#include "embed_ruby.hpp"
 #include "rice/Exception.hpp"
 #include "rice/Director.hpp"
 #include "rice/Constructor.hpp"
@@ -87,7 +88,7 @@ namespace {
 
 SETUP(Director)
 {
-  ruby_init();
+  embed_ruby();
 }
 
 TESTCASE(exposes_worker_as_instantiatable_class)

--- a/test/test_Enum.cpp
+++ b/test/test_Enum.cpp
@@ -1,4 +1,5 @@
 #include "unittest.hpp"
+#include "embed_ruby.hpp"
 #include "rice/Enum.hpp"
 #include "rice/Array.hpp"
 #include "rice/String.hpp"
@@ -26,7 +27,7 @@ namespace
 
 SETUP(Enum)
 {
-  ruby_init();
+  embed_ruby();
 }
 
 TESTCASE(copy_construct)

--- a/test/test_Exception.cpp
+++ b/test/test_Exception.cpp
@@ -1,4 +1,5 @@
 #include "unittest.hpp"
+#include "embed_ruby.hpp"
 #include "rice/Exception.hpp"
 #include "rice/String.hpp"
 
@@ -8,7 +9,7 @@ TESTSUITE(Exception);
 
 SETUP(Exception)
 {
-  ruby_init();
+  embed_ruby();
 }
 
 TESTCASE(construct_from_exception_object)

--- a/test/test_Hash.cpp
+++ b/test/test_Hash.cpp
@@ -1,4 +1,5 @@
 #include "unittest.hpp"
+#include "embed_ruby.hpp"
 #include "rice/Hash.hpp"
 #include "rice/global_function.hpp"
 #include <vector>
@@ -11,7 +12,7 @@ TESTSUITE(Hash);
 
 SETUP(Hash)
 {
-  ruby_init();
+  embed_ruby();
 }
 
 TESTCASE(default_construct)

--- a/test/test_Identifier.cpp
+++ b/test/test_Identifier.cpp
@@ -1,4 +1,5 @@
 #include "unittest.hpp"
+#include "embed_ruby.hpp"
 #include "rice/Identifier.hpp"
 #include "rice/Symbol.hpp"
 
@@ -8,7 +9,7 @@ TESTSUITE(Identifier);
 
 SETUP(Identifier)
 {
-  ruby_init();
+  embed_ruby();
 }
 
 TESTCASE(construct_from_id)

--- a/test/test_Memory_Management.cpp
+++ b/test/test_Memory_Management.cpp
@@ -1,4 +1,5 @@
 #include "unittest.hpp"
+#include "embed_ruby.hpp"
 #include "rice/String.hpp"
 #include "rice/Class.hpp"
 #include "rice/global_function.hpp"
@@ -9,7 +10,7 @@ TESTSUITE(Memory_Management);
 
 SETUP(Memory_Management)
 {
-  ruby_init();
+  embed_ruby();
 }
 
 namespace

--- a/test/test_Module.cpp
+++ b/test/test_Module.cpp
@@ -1,4 +1,5 @@
 #include "unittest.hpp"
+#include "embed_ruby.hpp"
 #include "rice/Module.hpp"
 #include "rice/Exception.hpp"
 #include "rice/Array.hpp"
@@ -12,7 +13,7 @@ TESTSUITE(Module);
 
 SETUP(Object)
 {
-  ruby_init();
+  embed_ruby();
 }
 
 TESTCASE(construct_from_value)

--- a/test/test_Object.cpp
+++ b/test/test_Object.cpp
@@ -1,4 +1,5 @@
 #include "unittest.hpp"
+#include "embed_ruby.hpp"
 #include "rice/Object.hpp"
 #include "rice/Class.hpp"
 #include "rice/String.hpp"
@@ -10,7 +11,7 @@ TESTSUITE(Object);
 
 SETUP(Object)
 {
-  ruby_init();
+  embed_ruby();
 }
 
 TESTCASE(default_construct)

--- a/test/test_String.cpp
+++ b/test/test_String.cpp
@@ -1,4 +1,5 @@
 #include "unittest.hpp"
+#include "embed_ruby.hpp"
 #include "rice/String.hpp"
 #include "rice/global_function.hpp"
 
@@ -8,7 +9,7 @@ TESTSUITE(String);
 
 SETUP(String)
 {
-  ruby_init();
+  embed_ruby();
 }
 
 TESTCASE(default_construct)

--- a/test/test_Struct.cpp
+++ b/test/test_Struct.cpp
@@ -1,4 +1,5 @@
 #include "unittest.hpp"
+#include "embed_ruby.hpp"
 #include "rice/Struct.hpp"
 #include "rice/Symbol.hpp"
 #include "rice/global_function.hpp"
@@ -22,7 +23,7 @@ namespace
 
 SETUP(Struct)
 {
-  ruby_init();
+  embed_ruby();
 }
 
 TESTCASE(default_construct)

--- a/test/test_Symbol.cpp
+++ b/test/test_Symbol.cpp
@@ -1,4 +1,5 @@
 #include "unittest.hpp"
+#include "embed_ruby.hpp"
 #include "rice/Symbol.hpp"
 #include "rice/Identifier.hpp"
 
@@ -8,7 +9,7 @@ TESTSUITE(Symbol);
 
 SETUP(Symbol)
 {
-  ruby_init();
+  embed_ruby();
 }
 
 TESTCASE(construct_from_symbol)

--- a/test/test_To_From_Ruby.cpp
+++ b/test/test_To_From_Ruby.cpp
@@ -1,4 +1,5 @@
 #include "unittest.hpp"
+#include "embed_ruby.hpp"
 #include "rice/to_from_ruby.hpp"
 #include "rice/String.hpp"
 #include "rice/Array.hpp"
@@ -12,7 +13,7 @@ TESTSUITE(To_From_Ruby);
 
 SETUP(To_From_Ruby)
 {
-  ruby_init();
+  embed_ruby();
 }
 
 TESTCASE(object_to_ruby)

--- a/test/test_global_functions.cpp
+++ b/test/test_global_functions.cpp
@@ -1,4 +1,5 @@
 #include "unittest.hpp"
+#include "embed_ruby.hpp"
 #include "rice/global_function.hpp"
 
 using namespace Rice;
@@ -7,7 +8,7 @@ TESTSUITE(GlobalFunction);
 
 SETUP(GlobalFunction)
 {
-  ruby_init();
+  embed_ruby();
 }
 
 namespace {


### PR DESCRIPTION
Embedding ruby requires more than just calling ruby_init - that always leads to exceptions on windows since ruby_sysinit is not called. This patch updates Ruby to be correctly initialized for tests. It also makes sure Ruby is only initialized once.