### PR TITLE
Discussion of support of EOL'd Ruby 2.5

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        ruby: [2.6, 2.7, 3.0]
+        ruby: [2.5, 2.6, 2.7, 3.0]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/rice.gemspec
+++ b/rice.gemspec
@@ -74,7 +74,7 @@ Ruby extensions with C++ easier.
     'test/ext/t2/*.*pp'
   ]
 
-  s.required_ruby_version = ">= 2.6"
+  s.required_ruby_version = ">= 2.5"
 
   s.add_development_dependency "bundler"
   s.add_development_dependency "rake"


### PR DESCRIPTION
We occured in a situation where we need to migrate to rice 4.0 with support of STL, and at the same time to support Ruby 2.5 for users (we support all versions starting from 2.5).

Currently rice 4.0.1 doesn't provide an `include` with STL, but supports Ruby 2.5.
On the other hand 4.0.2 provides the STL `include`, but drops Ruby 2.5.

Either restoration of Ruby 2.5, or dropping it since the `4.1.0` version (instead of `4.0.2`) would help with our issue.

@jasonroelofs What do you think?