### PR TITLE
Fixed crash in tests with Ruby 3.1

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        ruby: [2.5, 2.6, 2.7, '3.0']
+        ruby: [2.5, 2.6, 2.7, '3.0', 3.1]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/test/embed_ruby.cpp
+++ b/test/embed_ruby.cpp
@@ -21,8 +21,9 @@ void embed_ruby()
     // results in a crash.
     // See https://bugs.ruby-lang.org/issues/17643
     if (RUBY_API_VERSION_MAJOR == 3 &&
-        RUBY_API_VERSION_MINOR == 0 &&
-        RUBY_API_VERSION_TEENY == 0)
+       (RUBY_API_VERSION_MINOR == 1 ||
+       (RUBY_API_VERSION_MINOR == 0 &&
+        RUBY_API_VERSION_TEENY == 0)))
     {
       // do nothing
     }


### PR DESCRIPTION
This should fix the crash in tests with Ruby 3.1.

I think the cause is related to https://bugs.ruby-lang.org/issues/17643.