### PR TITLE
Added missing include

### DIFF
--- a/include/rice/rice.hpp
+++ b/include/rice/rice.hpp
@@ -304,6 +304,7 @@ namespace Rice::detail
 // ---------   Type.ipp   ---------
 
 #include <iosfwd>
+#include <iterator>
 #include <numeric>
 #include <regex>
 #include <sstream>

--- a/rice/detail/Type.ipp
+++ b/rice/detail/Type.ipp
@@ -1,6 +1,7 @@
 #include "rice_traits.hpp"
 
 #include <iosfwd>
+#include <iterator>
 #include <numeric>
 #include <regex>
 #include <sstream>


### PR DESCRIPTION
Fixes the following error on Fedora 36

```text
/root/rice/include/rice/rice.hpp: In function ‘std::string Rice::detail::makeClassName(const std::type_info&)’:
/root/rice/include/rice/rice.hpp:428:42: error: ‘istream_iterator’ is not a member of ‘std’
  428 |     std::vector<std::string> words{ std::istream_iterator<std::string>{stream},
      |                                          ^~~~~~~~~~~~~~~~
/root/rice/include/rice/rice.hpp:316:1: note: ‘std::istream_iterator’ is defined in header ‘<iterator>’; did you forget to ‘#include <iterator>’?
  315 | #include <cstring>
  +++ |+#include <iterator>
  316 | #endif
```

Ref: https://github.com/ankane/field_test/issues/39