### PR TITLE
Fix for std::bad_alloc in MethodInfo

### DIFF
--- a/include/rice/rice.hpp
+++ b/include/rice/rice.hpp
@@ -2822,7 +2822,7 @@ namespace Rice
     for (size_t i = this->args_.size(); i < argCount; i++)
     {
       Arg arg("arg_" + std::to_string(i));
-      this->args_.emplace_back(arg);
+      this->addArg(arg);
     }
 
     // TODO - so hacky but update the Arg positions

--- a/rice/detail/MethodInfo.ipp
+++ b/rice/detail/MethodInfo.ipp
@@ -13,7 +13,7 @@ namespace Rice
     for (size_t i = this->args_.size(); i < argCount; i++)
     {
       Arg arg("arg_" + std::to_string(i));
-      this->args_.emplace_back(arg);
+      this->addArg(arg);
     }
 
     // TODO - so hacky but update the Arg positions


### PR DESCRIPTION
Hi, I recently ran into a `std::bad_alloc` error when loading two gems that use Rice in the same script when one is precompiled (using [rake-compiler-dock](https://github.com/rake-compiler/rake-compiler-dock)). The issue occurs on Linux but not Mac (haven't tried Windows).

Debugging with gdb led to this backtrace, which seems to point to the `emplace_back` call in `MethodInfo`.

```text
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x00007ffff7aa3859 in __GI_abort () at abort.c:79
#2  0x00007ffff3e58911 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#3  0x00007ffff3e6438c in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007ffff3e643f7 in std::terminate() () from /lib/x86_64-linux-gnu/libstdc++.so.6
#5  0x00007ffff3e646fd in __cxa_rethrow () from /lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007ffff3fbbe44 in std::vector<Rice::Arg, std::allocator<Rice::Arg> >::_M_realloc_insert<Rice::Arg&> (
    this=0x555555799eb8, __position=...) at /usr/include/c++/9/ext/new_allocator.h:119
#7  0x00007ffff3d86f7c in Rice::Arg& std::vector<Rice::Arg, std::allocator<Rice::Arg> >::emplace_back<Rice::Arg&>(Rice::Arg&) () from /var/lib/gems/2.7.0/gems/tomoto-0.3.0-x86_64-linux/lib/tomoto/tomoto.so
#8  0x00007ffff3d86345 in Rice::MethodInfo::MethodInfo<>(unsigned long) ()
   from /var/lib/gems/2.7.0/gems/tomoto-0.3.0-x86_64-linux/lib/tomoto/tomoto.so
```

There's no error when all functions defined in C++ have either no args or all the args are specified with `Rice::Arg`, which also points to that code path.

Changing `MethodInfo` to call `addArg` (which calls `push_back`) fixes the issue. However, I don't fully understand why, so wanted to see if it makes sense to you.