### PR TITLE
Disable GC stress testing and re-enable failing test

### DIFF
--- a/test/embed_ruby.cpp
+++ b/test/embed_ruby.cpp
@@ -1,14 +1,6 @@
 #include <rice/rice.hpp>
 #include <ruby/version.h>
 
-// See https://bugs.ruby-lang.org/issues/17643. Note there is a function called 
-// rb_call_builtin_inits that properly intializes the GC and other modules.
-// It is exported on Windows builds (MSVC and MinGW) by the ruby shared library
-// so we can use it although it is not defined in any header.
-extern "C" {
-  void rb_call_builtin_inits(void);
-}
-
 void embed_ruby()
 {
   static bool initialized__ = false;
@@ -24,17 +16,5 @@ void embed_ruby()
     ruby_init_loadpath();
 
     initialized__ = true;
-
-    if constexpr (RUBY_API_VERSION_MAJOR < 3)
-    {
-      rb_eval_string("GC.stress = true");
-    }
-#ifdef _WIN64
-    else
-    {
-      rb_call_builtin_inits();
-      rb_eval_string("GC.stress = true");
-    }
-#endif
   }
 }

--- a/test/test_Array.cpp
+++ b/test/test_Array.cpp
@@ -215,10 +215,6 @@ TESTCASE(iterate_and_change)
   ASSERT_EQUAL(46, detail::From_Ruby<int>().convert(a[2].value()));
 }
 
-/**
- * This test is running into GC issues on CI. Entries in the array
- * are getting GC'd and the test is segfaulting. Really hard to reproduce
- * so disable for now.
 TESTCASE(iterate_and_call_member)
 {
   Array a;
@@ -240,7 +236,6 @@ TESTCASE(iterate_and_call_member)
   ASSERT_EQUAL(Object(a[1]).to_s(), v[1]);
   ASSERT_EQUAL(Object(a[2]).to_s(), v[2]);
 }
-*/
 
 TESTCASE(find_if)
 {


### PR DESCRIPTION
There are a couple of destructor-based tests that are failing regularly on Windows and for certain versions of Ruby on Mac. Not sure how to track these down but if we disable the stress testing they go away (which is odd becuase without stress testing the destructors actually get called?)

Not sure Ruby's GC stress testing is that great.