### PR TITLE
Move to using a library-based test runner

### DIFF
--- a/test/embed_ruby.cpp
+++ b/test/embed_ruby.cpp
@@ -1,14 +1,6 @@
 #include <rice/rice.hpp>
 #include <ruby/version.h>
 
-// See https://bugs.ruby-lang.org/issues/17643. Note there is a function called 
-// rb_call_builtin_inits that properly intializes the GC and other modules.
-// It is exported on Windows builds (MSVC and MinGW) by the ruby shared library
-// so we can use it although it is not defined in any header.
-extern "C" {
-  void rb_call_builtin_inits(void);
-}
-
 void embed_ruby()
 {
   static bool initialized__ = false;
@@ -24,17 +16,5 @@ void embed_ruby()
     ruby_init_loadpath();
 
     initialized__ = true;
-
-    if constexpr (RUBY_API_VERSION_MAJOR < 3)
-    {
-      rb_eval_string("GC.stress = true");
-    }
-#ifdef _WIN64
-    else
-    {
-      rb_call_builtin_inits();
-      rb_eval_string("GC.stress = true");
-    }
-#endif
   }
 }

--- a/test/extconf.rb
+++ b/test/extconf.rb
@@ -1,23 +1,25 @@
 require 'bundler/setup'
 require 'rice'
 require 'mkmf-rice'
-require 'rbconfig'
+
+create_makefile("unittest")
 
 # Totally hack mkmf to make a unittest executable instead of a shared library
-target_exe = "unittest#{RbConfig::CONFIG['EXEEXT']}"
-$cleanfiles << target_exe
-
-create_makefile(target_exe) do |conf|
-  conf << "\n"
-  conf << "#{target_exe}: $(OBJS)"
-  conf << "\t$(ECHO) linking executable unittest"
-  conf << "\t-$(Q)$(RM) $(@)"
-
-  if IS_MSWIN
-    conf << "\t$(Q) $(CXX) -Fe$(@) $(OBJS) $(LIBS) $(LOCAL_LIBS) -link $(ldflags) $(LIBPATH)"
-  else
-    conf << "\t$(Q) $(CXX) -o $@ $(OBJS) $(LIBPATH) $(LOCAL_LIBS) $(LIBS)"
-  end
-
-  conf << "\n"
-end
+#target_exe = "unittest#{RbConfig::CONFIG['EXEEXT']}"
+#$cleanfiles << target_exe
+#
+#create_makefile(target_exe) do |conf|
+#  conf << "\n"
+#  conf << "#{target_exe}: $(OBJS)"
+#  conf << "\t$(ECHO) linking executable unittest"
+#  conf << "\t-$(Q)$(RM) $(@)"
+#
+#  if IS_MSWIN
+#    conf << "\t$(Q) $(CXX) -Fe$(@) $(OBJS) $(LIBS) $(LOCAL_LIBS) -link $(ldflags) $(LIBPATH)"
+#  else
+#    conf << "\t$(Q) $(CXX) -o $@ $(OBJS) $(LIBPATH) $(LOCAL_LIBS) $(LIBS)"
+#  end
+#
+#  conf << "\n"
+#end
+#

--- a/test/run_all.rb
+++ b/test/run_all.rb
@@ -1,0 +1,21 @@
+require 'rubygems'
+gem 'minitest'
+require 'minitest/autorun'
+
+require_relative './unittest'
+
+TestSuite.all.each do |suite_name, test_suite|
+  Object.const_set("#{suite_name}Tests", Class.new(Minitest::Test) do
+    define_method("setup") do
+      test_suite.run_setup
+    end
+
+    test_suite.test_cases.each do |test_case|
+      define_method("test_#{test_case.name}") do
+        test_case.run
+#        puts test_case.run
+#        assert(false)
+      end
+    end
+  end)
+end

--- a/test/test_Address_Registration_Guard.cpp
+++ b/test/test_Address_Registration_Guard.cpp
@@ -1,15 +1,9 @@
 #include "unittest.hpp"
-#include "embed_ruby.hpp"
 #include <rice/rice.hpp>
 
 using namespace Rice;
 
 TESTSUITE(Address_Registration_Guard);
-
-SETUP(Address_Registration_Guard)
-{
-  embed_ruby();
-}
 
 TESTCASE(register_address)
 {

--- a/test/test_Array.cpp
+++ b/test/test_Array.cpp
@@ -1,5 +1,4 @@
 #include "unittest.hpp"
-#include "embed_ruby.hpp"
 #include <rice/rice.hpp>
 
 #include <vector>
@@ -17,11 +16,6 @@ namespace {
     }
     return os;
   }
-}
-
-SETUP(Array)
-{
-  embed_ruby();
 }
 
 TESTCASE(default_construct)
@@ -276,7 +270,7 @@ namespace {
 }
 
 TESTCASE(use_array_in_wrapped_function) {
-  define_global_function("test_array_arg", &testArrayArg);
+  define_global_function("get_array_arg", &testArrayArg);
 }
 
 TESTCASE(array_to_ruby)

--- a/test/test_Attribute.cpp
+++ b/test/test_Attribute.cpp
@@ -1,18 +1,12 @@
 #include <assert.h> 
 
 #include "unittest.hpp"
-#include "embed_ruby.hpp"
 #include <rice/rice.hpp>
 #include <rice/stl.hpp>
 
 using namespace Rice;
 
 TESTSUITE(Attribute);
-
-SETUP(Attribute)
-{
-  embed_ruby();
-}
 
 namespace
 {

--- a/test/test_Builtin_Object.cpp
+++ b/test/test_Builtin_Object.cpp
@@ -1,15 +1,9 @@
 #include "unittest.hpp"
-#include "embed_ruby.hpp"
 #include <rice/rice.hpp>
 
 using namespace Rice;
 
 TESTSUITE(Builtin_Object);
-
-SETUP(Builtin_Object)
-{
-  embed_ruby();
-}
 
 TESTCASE(construct_with_object)
 {

--- a/test/test_Class.cpp
+++ b/test/test_Class.cpp
@@ -1,15 +1,9 @@
 #include "unittest.hpp"
-#include "embed_ruby.hpp"
 #include <rice/rice.hpp>
 
 using namespace Rice;
 
 TESTSUITE(Class);
-
-SETUP(Class)
-{
-  embed_ruby();
-}
 
 TESTCASE(construct)
 {
@@ -31,19 +25,16 @@ TESTCASE(undef_creation_funcs)
 
 TESTCASE(include_module)
 {
-  Class c(anonymous_class());
+  Class c = define_class("AncestorsTestClass");
   Class & c2(c.include_module(rb_mEnumerable));
   ASSERT_EQUAL(&c, &c2);
   Array ancestors(c.ancestors());
-  Array expected_ancestors;
-  expected_ancestors.push(c);
-  expected_ancestors.push(Module(rb_mEnumerable));
-  expected_ancestors.push(Module(rb_cObject));
-  expected_ancestors.push(Module(rb_mKernel));
-#ifdef RUBY_VM
-  expected_ancestors.push(Module(rb_cBasicObject));
-#endif
-  ASSERT_EQUAL(expected_ancestors, ancestors);
+
+  VALUE hasClassAncestor = detail::protect(rb_eval_string, "AncestorsTestClass.ancestors.include?(AncestorsTestClass)");
+  VALUE hasEnumAncestor = detail::protect(rb_eval_string, "AncestorsTestClass.ancestors.include?(Enumerable)");
+
+  ASSERT_EQUAL(Qtrue, hasClassAncestor);
+  ASSERT_EQUAL(Qtrue, hasEnumAncestor);
 }
 
 namespace

--- a/test/test_Constructor.cpp
+++ b/test/test_Constructor.cpp
@@ -1,5 +1,4 @@
 #include "unittest.hpp"
-#include "embed_ruby.hpp"
 
 #include <rice/rice.hpp>
 
@@ -16,11 +15,6 @@ namespace
     {
     }
   };
-}
-
-SETUP(Array)
-{
-  embed_ruby();
 }
 
 TESTCASE(default_constructor)

--- a/test/test_Data_Object.cpp
+++ b/test/test_Data_Object.cpp
@@ -1,7 +1,6 @@
 #include <ruby/version.h>
 
 #include "unittest.hpp"
-#include "embed_ruby.hpp"
 #include <rice/rice.hpp>
 
 using namespace Rice;
@@ -43,8 +42,6 @@ namespace Rice
 
 SETUP(Data_Object)
 {
-  embed_ruby();
-
   if (!Data_Type<MyDataType>::is_bound())
   {
     Class object(rb_cObject);

--- a/test/test_Data_Type.cpp
+++ b/test/test_Data_Type.cpp
@@ -1,18 +1,12 @@
 #include <assert.h> 
 
 #include "unittest.hpp"
-#include "embed_ruby.hpp"
 #include <rice/rice.hpp>
 #include <rice/stl.hpp>
 
 using namespace Rice;
 
 TESTSUITE(Data_Type);
-
-SETUP(Data_Type)
-{
-  embed_ruby();
-}
 
 /**
  * The tests here are for the feature of taking an instance
@@ -268,6 +262,10 @@ TESTCASE(subclassing)
     define_method("another_method", &BaseClass::another_method);
 
     std::string code = R"(class ChildClass < BaseClass
+                            def initialize
+                              super
+                            end
+
                             def child_method
                               false
                             end

--- a/test/test_Director.cpp
+++ b/test/test_Director.cpp
@@ -1,5 +1,4 @@
 #include "unittest.hpp"
-#include "embed_ruby.hpp"
 #include <rice/rice.hpp>
 
 #include <vector>
@@ -93,11 +92,6 @@ namespace {
   };
 };
 
-SETUP(Director)
-{
-  embed_ruby();
-}
-
 TESTCASE(exposes_worker_as_instantiatable_class)
 {
   define_class<Worker>("Worker")
@@ -163,15 +157,15 @@ TESTCASE(super_calls_on_pure_virtual_raise_error)
 
 TESTCASE(polymorphic_calls_head_down_the_call_chain)
 {
-  define_class<Handler>("Handler")
-    .define_constructor(Constructor<Handler>())
-    .define_method("add_worker", &Handler::addWorker, Arg("worker").keepAlive())
-    .define_method("process_workers", &Handler::processWorkers);
-
   define_class<Worker>("Worker")
     .define_director<WorkerDirector>()
     .define_constructor(Constructor<WorkerDirector, Object>())
     .define_method("process", &WorkerDirector::default_process);
+
+  define_class<Handler>("Handler")
+    .define_constructor(Constructor<Handler>())
+    .define_method("add_worker", &Handler::addWorker, Arg("worker").keepAlive())
+    .define_method("process_workers", &Handler::processWorkers);
 
   Module m = define_module("Testing");
 
@@ -266,14 +260,14 @@ TESTCASE(mix_of_polymorphic_calls_and_inheritance_dont_cause_infinite_loops)
 
 TESTCASE(director_class_super_classes_get_type_bound)
 {
-  Module m = define_module("Testing");
-  m.define_module_function("get_calls_self", &getCallsSelf);
-
   define_class<CallsSelf>("CallsSelf")
     .define_director<CallsSelfDirector>()
     .define_constructor(Constructor<CallsSelfDirector, Rice::Object>())
     .define_method("do_it_impl", &CallsSelfDirector::default_doItImpl)
     .define_method("do_it", &CallsSelf::doIt);
+
+  Module m = define_module("Testing");
+  m.define_module_function("get_calls_self", &getCallsSelf);
 
   Object result = m.module_eval(R"(cs = Testing::get_calls_self
                                      cs.do_it(3))");
@@ -282,14 +276,14 @@ TESTCASE(director_class_super_classes_get_type_bound)
 
 TESTCASE(director_allows_abstract_types_used_as_parameters_pointers)
 {
-  Module m = define_module("Testing");
-  m.define_module_function("do_it_on_pointer", &doItOnPointer);
-
   define_class<CallsSelf>("CallsSelf")
     .define_director<CallsSelfDirector>()
     .define_constructor(Constructor<CallsSelfDirector, Rice::Object>())
     .define_method("do_it_impl", &CallsSelfDirector::default_doItImpl)
     .define_method("do_it", &CallsSelf::doIt);
+
+  Module m = define_module("Testing");
+  m.define_module_function("do_it_on_pointer", &doItOnPointer);
 
   Object result = m.module_eval(
       "class MySelf < CallsSelf; def do_it_impl(num); num * 10; end; end;"
@@ -302,14 +296,14 @@ TESTCASE(director_allows_abstract_types_used_as_parameters_pointers)
 
 TESTCASE(director_allows_abstract_types_used_as_parameters_reference)
 {
-  Module m = define_module("Testing");
-  m.define_module_function("do_it_on_ref", &doItOnReference);
-
   define_class<CallsSelf>("CallsSelf")
     .define_director<CallsSelfDirector>()
     .define_constructor(Constructor<CallsSelfDirector, Rice::Object>())
     .define_method("do_it_impl", &CallsSelfDirector::default_doItImpl)
     .define_method("do_it", &CallsSelf::doIt);
+
+  Module m = define_module("Testing");
+  m.define_module_function("do_it_on_ref", &doItOnReference);
 
   Object result = m.module_eval(
       "class MySelf < CallsSelf; def do_it_impl(num); num * 10; end; end;"

--- a/test/test_Enum.cpp
+++ b/test/test_Enum.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 
 #include "unittest.hpp"
-#include "embed_ruby.hpp"
 
 #include <rice/rice.hpp>
 
@@ -41,11 +40,6 @@ namespace
 
     return seasons;
   }
-}
-
-SETUP(Enum)
-{
-  embed_ruby();
 }
 
 TESTCASE(copy_construct)

--- a/test/test_Exception.cpp
+++ b/test/test_Exception.cpp
@@ -1,15 +1,9 @@
 #include "unittest.hpp"
-#include "embed_ruby.hpp"
 #include <rice/rice.hpp>
 
 using namespace Rice;
 
 TESTSUITE(Exception);
-
-SETUP(Exception)
-{
-  embed_ruby();
-}
 
 TESTCASE(construct_from_exception_object)
 {

--- a/test/test_Hash.cpp
+++ b/test/test_Hash.cpp
@@ -1,5 +1,4 @@
 #include "unittest.hpp"
-#include "embed_ruby.hpp"
 #include <rice/rice.hpp>
 
 #include <vector>
@@ -9,11 +8,6 @@
 using namespace Rice;
 
 TESTSUITE(Hash);
-
-SETUP(Hash)
-{
-  embed_ruby();
-}
 
 TESTCASE(default_construct)
 {
@@ -210,5 +204,5 @@ namespace {
 }
 
 TESTCASE(use_hash_in_wrapped_function) {
-  define_global_function("test_hash_arg", &testHashArg);
+  define_global_function("get_hash_arg", &testHashArg);
 }

--- a/test/test_Identifier.cpp
+++ b/test/test_Identifier.cpp
@@ -1,15 +1,9 @@
 #include "unittest.hpp"
-#include "embed_ruby.hpp"
 #include <rice/rice.hpp>
 
 using namespace Rice;
 
 TESTSUITE(Identifier);
-
-SETUP(Identifier)
-{
-  embed_ruby();
-}
 
 TESTCASE(construct_from_id)
 {

--- a/test/test_Inheritance.cpp
+++ b/test/test_Inheritance.cpp
@@ -1,7 +1,6 @@
 #include <assert.h> 
 
 #include "unittest.hpp"
-#include "embed_ruby.hpp"
 
 #include <rice/rice.hpp>
 #include <rice/stl.hpp>
@@ -72,7 +71,6 @@ Enum<NotificationType> createNotificationEnum()
 
 SETUP(Inheritance)
 {
-  embed_ruby();
   static Enum<NotificationType> NotificationEnum = createNotificationEnum();
 
   Data_Type<Notification>::unbind();

--- a/test/test_Iterator.cpp
+++ b/test/test_Iterator.cpp
@@ -1,15 +1,9 @@
 #include "unittest.hpp"
-#include "embed_ruby.hpp"
 #include <rice/rice.hpp>
 
 using namespace Rice;
 
 TESTSUITE(Iterator);
-
-SETUP(Iterator)
-{
-  embed_ruby();
-}
 
 namespace
 {

--- a/test/test_Keep_Alive.cpp
+++ b/test/test_Keep_Alive.cpp
@@ -1,5 +1,4 @@
 #include "unittest.hpp"
-#include "embed_ruby.hpp"
 #include <rice/rice.hpp>
 #include <rice/stl.hpp>
 
@@ -53,11 +52,6 @@ namespace
     private:
       std::vector<Listener*> mListeners;
   };
-}
-
-SETUP(Keep_Alive)
-{
-  embed_ruby();
 }
 
 TESTCASE(test_arg)

--- a/test/test_Memory_Management.cpp
+++ b/test/test_Memory_Management.cpp
@@ -1,15 +1,9 @@
 #include "unittest.hpp"
-#include "embed_ruby.hpp"
 #include <rice/rice.hpp>
 
 using namespace Rice;
 
 TESTSUITE(Memory_Management);
-
-SETUP(Memory_Management)
-{
-  embed_ruby();
-}
 
 namespace
 {

--- a/test/test_Module.cpp
+++ b/test/test_Module.cpp
@@ -1,5 +1,4 @@
 #include "unittest.hpp"
-#include "embed_ruby.hpp"
 
 #include <rice/rice.hpp>
 #include <rice/stl.hpp>
@@ -7,11 +6,6 @@
 using namespace Rice;
 
 TESTSUITE(Module);
-
-SETUP(Module)
-{
-  embed_ruby();
-}
 
 TESTCASE(FromConstant)
 {

--- a/test/test_Object.cpp
+++ b/test/test_Object.cpp
@@ -1,15 +1,9 @@
 #include "unittest.hpp"
-#include "embed_ruby.hpp"
 #include <rice/rice.hpp>
 
 using namespace Rice;
 
 TESTSUITE(Object);
-
-SETUP(Object)
-{
-  embed_ruby();
-}
 
 TESTCASE(default_construct)
 {

--- a/test/test_Ownership.cpp
+++ b/test/test_Ownership.cpp
@@ -1,5 +1,4 @@
 #include "unittest.hpp"
-#include "embed_ruby.hpp"
 #include <rice/rice.hpp>
 
 #include <memory>
@@ -115,8 +114,6 @@ namespace
 
 SETUP(Ownership)
 {
-  embed_ruby();
-
   define_class<MyClass>("MyClass").
     define_method("process", &MyClass::process).
     define_method("set_flag", &MyClass::setFlag);

--- a/test/test_Self.cpp
+++ b/test/test_Self.cpp
@@ -1,5 +1,4 @@
 #include "unittest.hpp"
-#include "embed_ruby.hpp"
 #include <rice/rice.hpp>
 
 #include <memory>
@@ -68,8 +67,6 @@ namespace
 
 SETUP(Self)
 {
-  embed_ruby();
-
   define_class<SelfClass>("SelfClass").
     define_constructor(Constructor<SelfClass>()).
     define_method("self_reference", &SelfClass::selfReference).

--- a/test/test_Stl_Map.cpp
+++ b/test/test_Stl_Map.cpp
@@ -2,18 +2,12 @@
 #include <memory>
 
 #include "unittest.hpp"
-#include "embed_ruby.hpp"
 #include <rice/rice.hpp>
 #include <rice/stl.hpp>
 
 using namespace Rice;
 
 TESTSUITE(Map);
-
-SETUP(Map)
-{
-  embed_ruby();
-}
 
 namespace
 {

--- a/test/test_Stl_Optional.cpp
+++ b/test/test_Stl_Optional.cpp
@@ -1,5 +1,4 @@
 #include "unittest.hpp"
-#include "embed_ruby.hpp"
 #include <rice/rice.hpp>
 #include <rice/stl.hpp>
 
@@ -46,7 +45,6 @@ Class makeOptionalClass()
 
 SETUP(Optional)
 {
-  embed_ruby();
   makeOptionalClass();
 }
 

--- a/test/test_Stl_Pair.cpp
+++ b/test/test_Stl_Pair.cpp
@@ -1,18 +1,12 @@
 #include <utility>
 
 #include "unittest.hpp"
-#include "embed_ruby.hpp"
 #include <rice/rice.hpp>
 #include <rice/stl.hpp>
 
 using namespace Rice;
 
 TESTSUITE(Pair);
-
-SETUP(Pair)
-{
-  embed_ruby();
-}
 
 TESTCASE(CreatePair)
 {

--- a/test/test_Stl_Reference_Wrapper.cpp
+++ b/test/test_Stl_Reference_Wrapper.cpp
@@ -1,5 +1,4 @@
 #include "unittest.hpp"
-#include "embed_ruby.hpp"
 #include <rice/rice.hpp>
 #include <rice/stl.hpp>
 
@@ -57,7 +56,6 @@ void makeReferenceWrapperClass()
 
 SETUP(ReferenceWrapper)
 {
-  embed_ruby();
   makeReferenceWrapperClass();
 }
 

--- a/test/test_Stl_SmartPointer.cpp
+++ b/test/test_Stl_SmartPointer.cpp
@@ -1,5 +1,4 @@
 #include "unittest.hpp"
-#include "embed_ruby.hpp"
 #include <rice/rice.hpp>
 #include <rice/stl.hpp>
 
@@ -96,8 +95,6 @@ namespace
 
 SETUP(SmartPointer)
 {
-  embed_ruby();
-
   define_class<MyClass>("MyClass").
     define_method("set_flag", &MyClass::setFlag);
 

--- a/test/test_Stl_String.cpp
+++ b/test/test_Stl_String.cpp
@@ -1,5 +1,4 @@
 #include "unittest.hpp"
-#include "embed_ruby.hpp"
 #include <rice/rice.hpp>
 #include <ruby/encoding.h>
 #include <rice/stl.hpp>
@@ -9,11 +8,6 @@
 using namespace Rice;
 
 TESTSUITE(StlString);
-
-SETUP(StlString)
-{
-  embed_ruby();
-}
 
 TESTCASE(std_string_to_ruby)
 {
@@ -27,13 +21,13 @@ TESTCASE(std_string_to_ruby_encoding)
   Object object(value);
   Object encoding = object.call("encoding");
   Object encodingName = encoding.call("name");
-  ASSERT_EQUAL("ASCII-8BIT", detail::From_Ruby<std::string>().convert(encodingName));
+  ASSERT_EQUAL("UTF-8", detail::From_Ruby<std::string>().convert(encodingName));
 }
 
 TESTCASE(std_string_to_ruby_encoding_utf8)
 {
   rb_encoding* defaultEncoding = rb_default_external_encoding();
-  
+
   VALUE utf8Encoding = rb_enc_from_encoding(rb_utf8_encoding());
   rb_enc_set_default_external(utf8Encoding);
 

--- a/test/test_Stl_Unordered_Map.cpp
+++ b/test/test_Stl_Unordered_Map.cpp
@@ -2,18 +2,12 @@
 #include <memory>
 
 #include "unittest.hpp"
-#include "embed_ruby.hpp"
 #include <rice/rice.hpp>
 #include <rice/stl.hpp>
 
 using namespace Rice;
 
 TESTSUITE(UnorderedMap);
-
-SETUP(UnorderedMap)
-{
-  embed_ruby();
-}
 
 namespace
 {

--- a/test/test_Stl_Variant.cpp
+++ b/test/test_Stl_Variant.cpp
@@ -1,5 +1,4 @@
 #include "unittest.hpp"
-#include "embed_ruby.hpp"
 #include <rice/rice.hpp>
 #include <rice/stl.hpp>
 
@@ -239,7 +238,6 @@ void makeClassVariant()
 
 SETUP(Variant)
 {
-  embed_ruby();
   makeIntrinsicVariant();
   makeClassVariant();
 }

--- a/test/test_Stl_Vector.cpp
+++ b/test/test_Stl_Vector.cpp
@@ -1,18 +1,12 @@
 #include <complex>
 
 #include "unittest.hpp"
-#include "embed_ruby.hpp"
 #include <rice/rice.hpp>
 #include <rice/stl.hpp>
 
 using namespace Rice;
 
 TESTSUITE(Vector);
-
-SETUP(Vector)
-{
-  embed_ruby();
-}
 
 namespace
 {

--- a/test/test_String.cpp
+++ b/test/test_String.cpp
@@ -1,15 +1,9 @@
 #include "unittest.hpp"
-#include "embed_ruby.hpp"
 #include <rice/rice.hpp>
 
 using namespace Rice;
 
 TESTSUITE(String);
-
-SETUP(String)
-{
-  embed_ruby();
-}
 
 TESTCASE(default_construct)
 {
@@ -103,5 +97,5 @@ namespace {
 }
 
 TESTCASE(use_string_in_wrapped_function) {
-  define_global_function("test_string_arg", &testStringArg);
+  define_global_function("get_string_arg", &testStringArg);
 }

--- a/test/test_Struct.cpp
+++ b/test/test_Struct.cpp
@@ -1,5 +1,4 @@
 #include "unittest.hpp"
-#include "embed_ruby.hpp"
 #include <rice/rice.hpp>
 
 using namespace Rice;
@@ -17,11 +16,6 @@ namespace
       .initialize(rb_mKernel, "Point");
     return rb_cPoint;
   }
-}
-
-SETUP(Struct)
-{
-  embed_ruby();
 }
 
 TESTCASE(default_construct)
@@ -192,5 +186,5 @@ namespace {
 }
 
 TESTCASE(use_struct_in_wrapped_function) {
-  define_global_function("test_struct_arg", &testStructArg);
+  define_global_function("get_struct_arg", &testStructArg);
 }

--- a/test/test_Symbol.cpp
+++ b/test/test_Symbol.cpp
@@ -1,15 +1,9 @@
 #include "unittest.hpp"
-#include "embed_ruby.hpp"
 #include <rice/rice.hpp>
 
 using namespace Rice;
 
 TESTSUITE(Symbol);
-
-SETUP(Symbol)
-{
-  embed_ruby();
-}
 
 TESTCASE(construct_from_symbol)
 {

--- a/test/test_To_From_Ruby.cpp
+++ b/test/test_To_From_Ruby.cpp
@@ -1,5 +1,4 @@
 #include "unittest.hpp"
-#include "embed_ruby.hpp"
 #include <rice/rice.hpp>
 
 #include <limits>
@@ -8,11 +7,6 @@
 using namespace Rice;
 
 TESTSUITE(To_From_Ruby);
-
-SETUP(To_From_Ruby)
-{
-  embed_ruby();
-}
 
 TESTCASE(object_to_ruby)
 {

--- a/test/test_Tracking.cpp
+++ b/test/test_Tracking.cpp
@@ -1,5 +1,4 @@
 #include "unittest.hpp"
-#include "embed_ruby.hpp"
 #include <rice/rice.hpp>
 
 #include <memory>
@@ -70,8 +69,6 @@ namespace
 
 SETUP(Tracking)
 {
-  embed_ruby();
-
   define_class<MyClass>("MyClass");
 
   define_class<Factory>("Factory").

--- a/test/test_global_functions.cpp
+++ b/test/test_global_functions.cpp
@@ -1,15 +1,9 @@
 #include "unittest.hpp"
-#include "embed_ruby.hpp"
 #include <rice/rice.hpp>
 
 using namespace Rice;
 
 TESTSUITE(GlobalFunction);
-
-SETUP(GlobalFunction)
-{
-  embed_ruby();
-}
 
 namespace {
 

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -1,6 +1,8 @@
 #include <algorithm>
 #include <iostream>
 #include <map>
+#include <rice/rice.hpp>
+#include <rice/stl.hpp>
 #include "unittest.hpp"
 
 size_t assertions;
@@ -158,5 +160,30 @@ int main(int argc, char** argv)
   }
 
   return (int)result.errors().size() + (int)result.failures().size();
+}
+
+extern "C" void Init_unittest() {
+
+  Rice::define_class<Test_Case>("TestCase")
+    .define_method("name", &Test_Case::name)
+    .define_method("run", &Test_Case::run);
+
+  Rice::define_class<Failure>("Failure")
+    .define_method("what", &Failure::what);
+
+  Rice::define_class<Test_Result>("TestResult")
+    .define_constructor(Rice::Constructor<Test_Result>())
+    .define_method("failures", &Test_Result::failures)
+    .define_method("errors", &Test_Result::errors);
+
+  Rice::Class cTestSuite = Rice::define_class<Test_Suite>("TestSuite")
+    .define_constructor(Rice::Constructor<Test_Suite, std::string>(), Rice::Arg("name") = (std::string)"")
+    .define_method("name", &Test_Suite::name)
+    .define_method("size", &Test_Suite::size)
+    .define_method("test_cases", &Test_Suite::test_cases)
+    .define_method("run_setup", &Test_Suite::run_setup);
+
+  Rice::define_map<std::map<std::string, Test_Suite>>("TestSuiteMap");
+  cTestSuite.define_singleton_function("all", &test_suites);
 }
 

--- a/test/unittest.hpp
+++ b/test/unittest.hpp
@@ -30,6 +30,8 @@ public:
 
   friend std::ostream & operator<<(std::ostream & out, Failure const & failure);
 
+  std::string what() { return what_; }
+
 private:
   std::string test_suite_name_;
   std::string test_case_name_;
@@ -94,6 +96,8 @@ private:
 class Test_Suite
 {
 public:
+  typedef std::vector<Test_Case> Test_Cases;
+
   Test_Suite(std::string const & name = "");
 
   void add_test_case(Test_Case const & test_case)
@@ -110,10 +114,17 @@ public:
 
   size_t size() const { return test_cases_.size(); }
 
+  Test_Cases test_cases() { return test_cases_; }
+
+  void run_setup() {
+    if (setup_) {
+      setup_();
+    }
+  }
+
 private:
   std::string name_;
 
-  typedef std::vector<Test_Case> Test_Cases;
   Test_Cases test_cases_;
 
   void (*setup_)();
@@ -236,7 +247,7 @@ void assert_equal(
 
     if constexpr (is_streamable<std::stringstream, T>::value && is_streamable<std::stringstream, U>::value)
     {
-      strm << s_t << " != " << s_u;
+      strm << "Expected `" << s_u << "` to be\n\n\t" << t << "\n\nbut was\n\n\t" << u << "\n\n";
     }
     strm << " at " << file << ":" << line;
     throw Assertion_Failed(strm.str());


### PR DESCRIPTION
This gets rid of the embedded-ruby version of the test suite, moving it to a dynamic library, built by Rice, to test Rice. This should provide a more consistent and reliable testing situation as everything runs in the single Ruby interpreter initialized by the normal `ruby` command line.