### PR TITLE
Fixed custom 'ruby_mark' code sample

### DIFF
--- a/doc/bindings/memory_management.rst
+++ b/doc/bindings/memory_management.rst
@@ -229,7 +229,7 @@ If you create classes or structures that reference Ruby objects, you need to imp
   namespace Rice
   {
     template<>
-    ruby_mark<MyClass>(const MyClass* myClass)
+    ruby_mark(const MyClass* myClass)
     {
       rb_gc_mark(myClass->value_);
     }


### PR DESCRIPTION
Just a small documentation fix ...

cc: @ronaldtse

This is a contribution from [Metanorma](https://www.metanorma.org) ([GitHub](https://github.com/metanorma)), a product of [Ribose](https://www.ribose.com) ([GitHub](https://github.com/riboseinc)). 