### PR TITLE
add support for experimental filesystem - fixes jasonroelofs/rice/197

### DIFF
--- a/include/rice/rice.hpp
+++ b/include/rice/rice.hpp
@@ -1205,8 +1205,17 @@ namespace Rice::detail
 // =========   cpp_protect.hpp   =========
 
 #include <regex>
-#include <filesystem>
 #include <stdexcept>
+
+#if __has_include(<filesystem>)
+  #include <filesystem>
+  namespace fs = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
+  #include <experimental/filesystem>
+  namespace fs = std::experimental::filesystem;
+#else
+  #error "no filesystem include found :'("
+#endif
 
 
 namespace Rice::detail
@@ -1247,7 +1256,7 @@ namespace Rice::detail
       {
         rb_exc_raise(rb_exc_new2(rb_eArgError, ex.what()));
       }
-      catch (std::filesystem::filesystem_error const& ex)
+      catch (fs::filesystem_error const& ex)
       {
         rb_exc_raise(rb_exc_new2(rb_eIOError, ex.what()));
       }

--- a/lib/mkmf-rice.rb
+++ b/lib/mkmf-rice.rb
@@ -126,5 +126,7 @@ end
 if IS_DARWIN
   have_library('c++')
 elsif !IS_MSWIN
-  have_library('stdc++')
+  if !have_library('stdc++fs')
+    have_library('stdc++')
+  end
 end

--- a/rice/detail/cpp_protect.hpp
+++ b/rice/detail/cpp_protect.hpp
@@ -2,8 +2,17 @@
 #define Rice__detail__cpp_protect__hpp_
 
 #include <regex>
-#include <filesystem>
 #include <stdexcept>
+
+#if __has_include(<filesystem>)
+  #include <filesystem>
+  namespace fs = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
+  #include <experimental/filesystem>
+  namespace fs = std::experimental::filesystem;
+#else
+  #error "no filesystem include found :'("
+#endif
 
 #include "Jump_Tag.hpp"
 #include "../Exception_defn.hpp"
@@ -46,7 +55,7 @@ namespace Rice::detail
       {
         rb_exc_raise(rb_exc_new2(rb_eArgError, ex.what()));
       }
-      catch (std::filesystem::filesystem_error const& ex)
+      catch (fs::filesystem_error const& ex)
       {
         rb_exc_raise(rb_exc_new2(rb_eIOError, ex.what()));
       }


### PR DESCRIPTION
Fixes https://github.com/jasonroelofs/rice/issues/197

This works on Ubuntu 22.04 and Amazon Linux 2. 
I _believe_ `__has_include` was added in c++17