### PR TITLE
better constructors from `string` for `Identifier` and `Symbol`

### DIFF
--- a/include/rice/rice.hpp
+++ b/include/rice/rice.hpp
@@ -3695,7 +3695,7 @@ namespace Rice
     Identifier(char const* s);
 
     //! Construct a new Identifier from a string.
-    Identifier(std::string const string);
+    Identifier(std::string const& string);
 
     //! Return a string representation of the Identifier.
     char const* c_str() const;
@@ -3729,7 +3729,7 @@ namespace Rice
   {
   }
 
-  inline Identifier::Identifier(std::string const s) : id_(rb_intern(s.c_str()))
+  inline Identifier::Identifier(std::string const& s) : id_(rb_intern2(s.c_str(), s.size()))
   {
   }
 
@@ -6273,7 +6273,7 @@ namespace Rice
   }
 
   inline Symbol::Symbol(std::string const& s)
-    : Object(detail::protect(rb_id2sym, detail::protect(rb_intern, s.c_str())))
+    : Object(detail::protect(rb_id2sym, detail::protect(rb_intern2, s.c_str(), s.size())))
   {
   }
 

--- a/rice/Identifier.hpp
+++ b/rice/Identifier.hpp
@@ -23,7 +23,7 @@ namespace Rice
     Identifier(char const* s);
 
     //! Construct a new Identifier from a string.
-    Identifier(std::string const string);
+    Identifier(std::string const& string);
 
     //! Return a string representation of the Identifier.
     char const* c_str() const;

--- a/rice/Identifier.ipp
+++ b/rice/Identifier.ipp
@@ -8,7 +8,7 @@ namespace Rice
   {
   }
 
-  inline Identifier::Identifier(std::string const s) : id_(rb_intern(s.c_str()))
+  inline Identifier::Identifier(std::string const& s) : id_(rb_intern2(s.c_str(), s.size()))
   {
   }
 

--- a/rice/cpp_api/Symbol.ipp
+++ b/rice/cpp_api/Symbol.ipp
@@ -16,7 +16,7 @@ namespace Rice
   }
 
   inline Symbol::Symbol(std::string const& s)
-    : Object(detail::protect(rb_id2sym, detail::protect(rb_intern, s.c_str())))
+    : Object(detail::protect(rb_id2sym, detail::protect(rb_intern2, s.c_str(), s.size())))
   {
   }
 


### PR DESCRIPTION
This PR accomplishes two things:

1. No need to construct a temporary string object just for `Identifier()`; and
2. No need to duplicate effort to calculate the string length in `rb_intern` when we already have it available in the caller.